### PR TITLE
fix: add windows line ending support to edit editors feature

### DIFF
--- a/src/commands/edit-editors.ts
+++ b/src/commands/edit-editors.ts
@@ -22,7 +22,6 @@ function isEditor(editor: string) {
         return true;
     }
     if (!isWindows()) {
-        editor.startsWith(getSlash());
         return editor.startsWith(getSlash());
     }
     return DRIVES.some(drive => editor.startsWith(drive));
@@ -39,7 +38,7 @@ export default function createEditEditorsCommand(
                 e.document.save();
                 activeProjectService.activeEditors = e.document
                     .getText()
-                    .split("\n")
+                    .split(/\r?\n/)
                     .filter(isEditor)
                     .map(editor => ({
                         fileName: editor,


### PR DESCRIPTION
Fixes an issue in the "edit editors" feature on Windows, where the carriage return character (`\r`) is not being stripped from line endings. Due to this, all filler values (`_`) are inadvertently filtered out from the active editors array when the `vscodeHarpoon.harpoon` document is closed.

Also, a redundant line in the `isEditor` function has been removed.
