### PR TITLE
Quick Pick Visible Context for Use With “when” Clauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ You are then able to jump to `editor 1` or `editor 2` from anywhere in your work
   pick menu to pick between your global editors
 - `VSCode Harpoon: Go to previous global harpoon editor (vscode-harpoon.gotoPreviousGlobalHarpoonEditor)` Jumps to the previous global editor which was last jumped from using harpoon.
 
+### Available Contexts
+
+- `VSCode Harpoon: Quick Pick Visible (vscode-harpoon.isQuickPick)` Adds context for determining whether harpoon's quick pick list is visible.
+
+
 ## Troubleshooting
 
 If desired the extension does support jumping to already open editors in different split panes. However, for this to work you need to add a property to your settings.json:

--- a/package.json
+++ b/package.json
@@ -201,6 +201,10 @@
             {
                 "command": "vscode-harpoon.gotoPreviousGlobalHarpoonEditor",
                 "title": "VSCode Harpoon: Go to previous global harpoon editor"
+            },
+            {
+                "command": "vscode-harpoon.isQuickPick",
+                "title": "VSCode Harpoon: Quick Pick Visible"
             }
         ]
     },

--- a/src/commands/editor-quick-pick.ts
+++ b/src/commands/editor-quick-pick.ts
@@ -59,7 +59,7 @@ export default function createEditorQuickPickCommand(
 
         quickPick.onDidHide(() => { 
             workspaceService.setQuickPickContext(false);
-            quickPick.dispose ;
+            quickPick.dispose();
         });
         quickPick.show();
     };

--- a/src/commands/editor-quick-pick.ts
+++ b/src/commands/editor-quick-pick.ts
@@ -9,6 +9,8 @@ export default function createEditorQuickPickCommand(
 ) {
     return async () => {
         const quickPick = vscode.window.createQuickPick();
+        workspaceService.setQuickPickContext(true);
+
         quickPick.items = activeProjectService.activeEditors.reduce((acc, editor, i) => {
             if (editor.fileName !== "_") {
                 acc.push(toQuickPickItem(editor, i));
@@ -55,7 +57,10 @@ export default function createEditorQuickPickCommand(
             }
         });
 
-        quickPick.onDidHide(quickPick.dispose);
+        quickPick.onDidHide(() => { 
+            workspaceService.setQuickPickContext(false);
+            quickPick.dispose ;
+        });
         quickPick.show();
     };
 }

--- a/src/service/workspace-service.ts
+++ b/src/service/workspace-service.ts
@@ -32,6 +32,10 @@ export default class WorkspaceService {
         });
     }
 
+    public setQuickPickContext(isQuickPick: boolean) {
+        vscode.commands.executeCommand("setContext", "vscode-harpoon.isQuickPick", isQuickPick)
+    }
+
     private async trackedPreviousEditor<T>(cb: () => Promise<T>): Promise<T> {
         const activeEditor = vscode.window.activeTextEditor;
         if (!activeEditor) {

--- a/src/service/workspace-service.ts
+++ b/src/service/workspace-service.ts
@@ -33,7 +33,7 @@ export default class WorkspaceService {
     }
 
     public setQuickPickContext(isQuickPick: boolean) {
-        vscode.commands.executeCommand("setContext", "vscode-harpoon.isQuickPick", isQuickPick)
+        vscode.commands.executeCommand("setContext", "vscode-harpoon.isQuickPick", isQuickPick);
     }
 
     private async trackedPreviousEditor<T>(cb: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
**Summary**
- Add `setQuickPickContext(bool)` to toggle context on (true) and off (false).
- Calls `setQuickPickContext(bool)` during Quick Pick create and `onDidHide()`.

**Why did I add this?**
I prefer to use 'j' and 'k' without modifiers for navigating through my Harpoon Quick Pick list. This behaviour is similar to how the Neovim plugin works. I wasn't able to find the correct combination of VS Code native contexts for my "when" clause to replicate this behaviour, so I thought to just add it.

Let me know if this PR needs any attention. I'd really like to get this through.