### PR TITLE
fix: remove isQuickPick context from commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,10 +201,6 @@
             {
                 "command": "vscode-harpoon.gotoPreviousGlobalHarpoonEditor",
                 "title": "VSCode Harpoon: Go to previous global harpoon editor"
-            },
-            {
-                "command": "vscode-harpoon.isQuickPick",
-                "title": "VSCode Harpoon: Quick Pick Visible"
             }
         ]
     },


### PR DESCRIPTION
- Removed the *vscode-harpoon.isQuickPick* command from *package.json* to ensure it does not show up as a Harpoon command.
- Fixes issue described in #34 