### PR TITLE
feat: navigate next and navigate previous commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You are then able to jump to `editor 1` or `editor 2` from anywhere in your work
 - `VSCode Harpoon: Editor Global Quick Pick (vscode-harpoon.editorGlobalQuickPick)` Opens a quick
   pick menu to pick between your global editors
 - `VSCode Harpoon: Go to previous global harpoon editor (vscode-harpoon.gotoPreviousGlobalHarpoonEditor)` Jumps to the previous global editor which was last jumped from using harpoon.
+- `VSCode Harpoon: Navigate Next Editor (vscode-harpoon.navigateNextEditor)` Jumps to the next workspace editor.
+- `VSCode Harpoon: Navigate Previous Editor (vscode-harpoon.navigatePreviousEditor)` Jumps to the previous workspace editor.
 
 ### Available Contexts
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
     "contributes": {
         "commands": [
             {
+                "command": "vscode-harpoon.navigateNextEditor",
+                "title": "VSCode Harpoon: Navigate Next Editor"
+            },
+            {
+                "command": "vscode-harpoon.navigatePreviousEditor",
+                "title": "VSCode Harpoon: Navigate Previous Editor"
+            },
+            {
                 "command": "vscode-harpoon.addEditor",
                 "title": "VSCode Harpoon: Add Editor"
             },

--- a/src/commands/command-factory.ts
+++ b/src/commands/command-factory.ts
@@ -1,6 +1,10 @@
 import * as vscode from "vscode";
 
 type CommandName =
+    | "navigateNextEditor"
+    | "navigateGlobalNextEditor"
+    | "navigatePreviousEditor"
+    | "navigateGlobalPreviousEditor"
     | "addEditor"
     | "editEditors"
     | "addEditor1"

--- a/src/commands/navigate-editor.ts
+++ b/src/commands/navigate-editor.ts
@@ -1,0 +1,38 @@
+import * as vscode from "vscode";
+import ActiveProjectService, { Editor } from "../service/active-project-service";
+import WorkspaceService from "../service/workspace-service";
+
+export type NavigationDirection = "navigateNext" | "navigatePrevious";
+
+export default function createNavigateEditorCommand(
+    activeProjectService: ActiveProjectService,
+    workspaceService: WorkspaceService,
+    direction: NavigationDirection
+) {
+    return () => {
+        if (activeProjectService.activeEditors.length < 1) {
+            return;
+        }
+        const activeEditor = vscode.window.activeTextEditor;
+        if (!activeEditor) {
+            return;
+        }
+        const currentEditor: Editor = {
+            fileName: activeEditor.document.fileName,
+        };
+        const currentEditorIndex = activeProjectService.activeEditors.findIndex(
+            editor => editor.fileName === currentEditor.fileName
+        );
+        if (currentEditorIndex !== -1 && activeProjectService.activeEditors.length === 1) {
+            return;
+        }
+
+        const nextNonFillerEditorIndex = activeProjectService.getNextNonFillerEditorIndex(
+            currentEditorIndex,
+            direction
+        );
+        if (nextNonFillerEditorIndex !== -1) {
+            workspaceService.changeEditorById(nextNonFillerEditorIndex + 1);
+        }
+    };
+}

--- a/src/harpoon.ts
+++ b/src/harpoon.ts
@@ -8,6 +8,7 @@ import createAddEditorCommand from "./commands/add-editor";
 import createEditEditorsCommand from "./commands/edit-editors";
 import createEditorQuickPickCommand from "./commands/editor-quick-pick";
 import createGotoPreviousHarpoonEditorCommand from "./commands/goto-previous-harpoon-editor";
+import createNavigateEditorCommand from "./commands/navigate-editor";
 
 export type State = "workspaceState" | "globalState";
 
@@ -80,5 +81,13 @@ function registerCommands(
     commandFactory.registerCommand(
         `gotoPrevious${key}HarpoonEditor`,
         createGotoPreviousHarpoonEditorCommand(activeProjectService, workspaceService)
+    );
+    commandFactory.registerCommand(
+        `navigate${key}NextEditor`,
+        createNavigateEditorCommand(activeProjectService, workspaceService, "navigateNext")
+    );
+    commandFactory.registerCommand(
+        `navigate${key}PreviousEditor`,
+        createNavigateEditorCommand(activeProjectService, workspaceService, "navigatePrevious")
     );
 }

--- a/src/service/active-project-service.ts
+++ b/src/service/active-project-service.ts
@@ -1,3 +1,5 @@
+import { NavigationDirection } from "../commands/navigate-editor";
+
 export type Editor = {
     editorId?: number;
     fileName: string;
@@ -38,6 +40,44 @@ export default class ActiveProjectService {
 
     public getEditor(id: number) {
         return this._activeEditors[id - 1];
+    }
+
+    public getNextNonFillerEditorIndex(currentEditorIndex: number, direction: NavigationDirection) {
+        if (direction === "navigateNext") {
+            const nextIndex = this.findNextNonFillerEditorIndex(currentEditorIndex + 1);
+            return nextIndex !== -1
+                ? nextIndex
+                : this.findNextNonFillerEditorIndex(0, currentEditorIndex);
+        }
+
+        const nextIndex = this.findPreviousNonFillerEditorIndex(currentEditorIndex - 1);
+        return nextIndex !== -1
+            ? nextIndex
+            : this.findPreviousNonFillerEditorIndex(this._activeEditors.length - 1, currentEditorIndex + 1);
+    }
+
+    private findNextNonFillerEditorIndex(fromIndex: number, toIndex: number = this._activeEditors.length) {
+        for (let i = fromIndex; i < toIndex; i++) {
+            if (!this.isFillerEditor(this._activeEditors[i])) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private findPreviousNonFillerEditorIndex(fromIndex: number, toIndex: number = 0) {
+        for (let i = fromIndex; i >= toIndex; i--) {
+            if (!this.isFillerEditor(this._activeEditors[i])) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private isFillerEditor(editor: Editor): boolean {
+        return editor.fileName === "_";
     }
 
     public set activeEditors(editors: Editor[]) {


### PR DESCRIPTION
Replicate the Harpoon ```nav_next``` and ```nav_prev``` functions to enable cycling through the list in both directions. Closes https://github.com/tobias-z/vscode-harpoon/issues/33

- **Navigate Next Editor**: Navigate to the next editor in the list. If there are no more elements to reach, it jumps back to the first element.
- **Navigate Previous Edito**r:  Navigate to the previous editor in the list. If there are no previous elements, it jumps to the last element.
